### PR TITLE
Refactor DomainStatus and adapter flow

### DIFF
--- a/src/adapters/dohAdapter.ts
+++ b/src/adapters/dohAdapter.ts
@@ -1,4 +1,4 @@
-import { CheckerAdapter, DomainStatus } from '../types.js';
+import { CheckerAdapter, AdapterResponse } from '../types.js';
 
 export class DohAdapter implements CheckerAdapter {
   namespace = 'dns.doh';
@@ -7,24 +7,39 @@ export class DohAdapter implements CheckerAdapter {
     this.url = url;
   }
 
-  async check(domain: string, opts: { signal?: AbortSignal } = {}): Promise<DomainStatus> {
-    const params = new URLSearchParams({ name: domain, type: 'A' });
-    const res = await fetch(`${this.url}?${params.toString()}`, {
-      headers: { accept: 'application/dns-json' },
-      signal: opts.signal,
-    });
-    if (!res.ok) {
-      throw new Error(`doh query failed: ${res.status}`);
+  async check(domain: string, opts: { signal?: AbortSignal } = {}): Promise<AdapterResponse> {
+    try {
+      const params = new URLSearchParams({ name: domain, type: 'A' });
+      const res = await fetch(`${this.url}?${params.toString()}`, {
+        headers: { accept: 'application/dns-json' },
+        signal: opts.signal,
+      });
+      if (!res.ok) {
+        return {
+          domain,
+          availability: 'unknown',
+          source: 'dns.doh',
+          raw: null,
+          error: new Error(`doh query failed: ${res.status}`),
+        };
+      }
+      const data = await res.json();
+      const answers = data.Answer || [];
+      const available = answers.length === 0;
+      return {
+        domain,
+        availability: available ? 'available' : 'unavailable',
+        source: 'dns.doh',
+        raw: data,
+      };
+    } catch (err: any) {
+      return {
+        domain,
+        availability: 'unknown',
+        source: 'dns.doh',
+        raw: null,
+        error: err,
+      };
     }
-    const data = await res.json();
-    const answers = data.Answer || [];
-    const available = answers.length === 0;
-    return {
-      domain,
-      availability: available ? 'available' : 'unavailable',
-      source: 'dns.doh',
-      raw: { [this.namespace]: data },
-      timestamp: Date.now(),
-    };
   }
 }

--- a/src/adapters/hostAdapter.ts
+++ b/src/adapters/hostAdapter.ts
@@ -1,18 +1,16 @@
-import { CheckerAdapter, DomainStatus } from '../types.js';
+import { CheckerAdapter, AdapterResponse } from '../types.js';
 import { promises as dns } from 'dns';
 
 export class HostAdapter implements CheckerAdapter {
   namespace = 'dns.host';
-  async check(domain: string, opts: { signal?: AbortSignal } = {}): Promise<DomainStatus> {
-    const start = Date.now();
+  async check(domain: string, opts: { signal?: AbortSignal } = {}): Promise<AdapterResponse> {
     try {
       await dns.resolve(domain, 'A');
       return {
         domain,
         availability: 'unavailable',
         source: 'dns.host',
-        raw: { [this.namespace]: true },
-        timestamp: Date.now(),
+        raw: true,
       };
     } catch (err: any) {
       if (err.code === 'ENODATA' || err.code === 'ENOTFOUND') {
@@ -20,12 +18,16 @@ export class HostAdapter implements CheckerAdapter {
           domain,
           availability: 'available',
           source: 'dns.host',
-          raw: { [this.namespace]: false },
-          timestamp: Date.now(),
+          raw: false,
         };
       }
-      console.log("dns.host: error: " + err.code)
-      throw err;
+      return {
+        domain,
+        availability: 'unknown',
+        source: 'dns.host',
+        raw: null,
+        error: err,
+      };
     }
   }
 }

--- a/src/adapters/rdapAdapter.ts
+++ b/src/adapters/rdapAdapter.ts
@@ -1,4 +1,4 @@
-import { CheckerAdapter, DomainStatus, TldConfigEntry } from '../types.js';
+import { CheckerAdapter, AdapterResponse, TldConfigEntry } from '../types.js';
 
 export class RdapAdapter implements CheckerAdapter {
   namespace = 'rdap';
@@ -10,33 +10,43 @@ export class RdapAdapter implements CheckerAdapter {
   async check(
     domain: string,
     opts: { signal?: AbortSignal; tldConfig?: TldConfigEntry } = {}
-  ): Promise<DomainStatus> {
+  ): Promise<AdapterResponse> {
     const baseUrl = opts.tldConfig?.rdapServer || this.baseUrl;
-    const res = await fetch(`${baseUrl}${domain}`, { signal: opts.signal });
-    const text = await res.text();
-    if(text) {
-      console.log('\n\nrdap.text', domain, text);
-    }
-    if (res.status === 404) {
-      console.log("rdap.404: ", domain, text )
+    try {
+      const res = await fetch(`${baseUrl}${domain}`, { signal: opts.signal });
+      const text = await res.text();
+      if (res.status === 404) {
+        return {
+          domain,
+          availability: 'available',
+          source: 'rdap',
+          raw: null,
+        };
+      }
+      if (!res.ok) {
+        return {
+          domain,
+          availability: 'unknown',
+          source: 'rdap',
+          raw: text,
+          error: new Error(`rdap failed: ${res.status}`),
+        };
+      }
+      const data = JSON.parse(text);
       return {
         domain,
-        availability: 'available',
+        availability: 'unavailable',
         source: 'rdap',
-        raw: { [this.namespace]: null },
-        timestamp: Date.now(),
+        raw: data,
+      };
+    } catch (err: any) {
+      return {
+        domain,
+        availability: 'unknown',
+        source: 'rdap',
+        raw: null,
+        error: err,
       };
     }
-    if (!res.ok) {
-      throw new Error(`rdap failed: ${res.status}`);
-    }
-    const data = JSON.parse(text);
-    return {
-      domain,
-      availability: 'unavailable',
-      source: 'rdap',
-      raw: { [this.namespace]: data },
-      timestamp: Date.now(),
-    };
   }
 }

--- a/src/adapters/whoisApiAdapter.ts
+++ b/src/adapters/whoisApiAdapter.ts
@@ -1,4 +1,4 @@
-import { CheckerAdapter, DomainStatus } from '../types.js';
+import { CheckerAdapter, AdapterResponse } from '../types.js';
 
 export class WhoisApiAdapter implements CheckerAdapter {
   namespace = 'whois.api';
@@ -31,26 +31,36 @@ export class WhoisApiAdapter implements CheckerAdapter {
     return JSON.parse(text);
   }
 
-  async check(domain: string, opts: { signal?: AbortSignal } = {}): Promise<DomainStatus> {
-    let data: any;
+  async check(domain: string, opts: { signal?: AbortSignal } = {}): Promise<AdapterResponse> {
     try {
-      data = await this.fetchFreaks(domain, opts.signal);
-    } catch (err: any) {
-      if (err.quota) {
-        data = await this.fetchXml(domain, opts.signal);
-      } else {
-        throw err;
+      let data: any;
+      try {
+        data = await this.fetchFreaks(domain, opts.signal);
+      } catch (err: any) {
+        if (err.quota) {
+          data = await this.fetchXml(domain, opts.signal);
+        } else {
+          throw err;
+        }
       }
-    }
 
-    const text = JSON.stringify(data).toLowerCase();
-    const isAvailable = text.includes('n/a') || text.includes('no match') || text.includes('not found');
-    return {
-      domain,
-      availability: isAvailable ? 'available' : 'unavailable',
-      source: 'whois.api',
-      raw: { [this.namespace]: data },
-      timestamp: Date.now(),
-    };
+      const text = JSON.stringify(data).toLowerCase();
+      const isAvailable =
+        text.includes('n/a') || text.includes('no match') || text.includes('not found');
+      return {
+        domain,
+        availability: isAvailable ? 'available' : 'unavailable',
+        source: 'whois.api',
+        raw: data,
+      };
+    } catch (err: any) {
+      return {
+        domain,
+        availability: 'unknown',
+        source: 'whois.api',
+        raw: null,
+        error: err,
+      };
+    }
   }
 }

--- a/src/adapters/whoisCliAdapter.ts
+++ b/src/adapters/whoisCliAdapter.ts
@@ -1,4 +1,4 @@
-import { CheckerAdapter, DomainStatus } from '../types.js';
+import { CheckerAdapter, AdapterResponse } from '../types.js';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 
@@ -6,23 +6,32 @@ const execAsync = promisify(exec);
 
 export class WhoisCliAdapter implements CheckerAdapter {
   namespace = 'whois.lib';
-  async check(domain: string): Promise<DomainStatus> {
-    const cmd = `whois ${domain}`;
-    const { stdout } = await execAsync(cmd, { maxBuffer: 1024 * 1024 });
-    const text = stdout.toLowerCase();
-    const availablePatterns = [
-      'no match',
-      'not found',
-      'no entries found',
-      'status: available',
-    ];
-    const isAvailable = availablePatterns.some((p) => text.includes(p));
-    return {
-      domain,
-      availability: isAvailable ? 'available' : 'unavailable',
-      source: 'whois.lib',
-      raw: { [this.namespace]: stdout },
-      timestamp: Date.now(),
-    };
+  async check(domain: string): Promise<AdapterResponse> {
+    try {
+      const cmd = `whois ${domain}`;
+      const { stdout } = await execAsync(cmd, { maxBuffer: 1024 * 1024 });
+      const text = stdout.toLowerCase();
+      const availablePatterns = [
+        'no match',
+        'not found',
+        'no entries found',
+        'status: available',
+      ];
+      const isAvailable = availablePatterns.some((p) => text.includes(p));
+      return {
+        domain,
+        availability: isAvailable ? 'available' : 'unavailable',
+        source: 'whois.lib',
+        raw: stdout,
+      };
+    } catch (err: any) {
+      return {
+        domain,
+        availability: 'unknown',
+        source: 'whois.lib',
+        raw: null,
+        error: err,
+      };
+    }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,25 +1,49 @@
-export interface DomainStatus {
+
+export type Availability =
+  | 'available'
+  | 'unavailable'
+  | 'unsupported'
+  | 'invalid'
+  | 'unknown';
+
+export type AdapterSource =
+  | 'validator'
+  | 'dns.host'
+  | 'dns.doh'
+  | 'rdap'
+  | 'whois.lib'
+  | 'whois.api'
+  | 'app';
+
+export interface AdapterResponse {
   domain: string;
-  availability: 'available' | 'unavailable' | 'unsupported' | 'invalid' | 'unknown';
+  availability: Availability;
   fineStatus?:
     | 'expiring_soon'
     | 'registered_not_in_use'
     | 'premium'
     | 'for_sale'
     | 'reserved';
-  source:
-    | 'validator'
-    | 'dns.host'
-    | 'dns.doh'
-    | 'rdap'
-    | 'whois.lib'
-    | 'whois.api'
-    | 'app';
+  source: AdapterSource;
+  raw: any;
+  error?: Error;
+}
+
+export interface DomainStatus {
+  domain: string;
+  availability: Availability;
+  fineStatus?:
+    | 'expiring_soon'
+    | 'registered_not_in_use'
+    | 'premium'
+    | 'for_sale'
+    | 'reserved';
+  resolver: AdapterSource;
   /**
    * Raw responses from each adapter keyed by its namespace.
    */
   raw: Record<string, any>;
-  timestamp: number;
+  error?: Error;
 }
 
 export interface CheckerAdapter {
@@ -28,7 +52,7 @@ export interface CheckerAdapter {
   check(
     domain: string,
     opts?: { signal?: AbortSignal; tldConfig?: TldConfigEntry }
-  ): Promise<DomainStatus>;
+  ): Promise<AdapterResponse>;
 }
 
 export interface TldConfigEntry {

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -19,9 +19,9 @@ export function validateDomain(domain: string): {
       status: {
         domain,
         availability: 'invalid',
-        source: 'validator',
+        resolver: 'validator',
         raw: { validator: null },
-        timestamp: Date.now(),
+        error: undefined,
       },
     };
   }
@@ -32,9 +32,9 @@ export function validateDomain(domain: string): {
       status: {
         domain,
         availability: 'unsupported',
-        source: 'validator',
+        resolver: 'validator',
         raw: { validator: null },
-        timestamp: Date.now(),
+        error: undefined,
       },
     };
   }
@@ -47,9 +47,9 @@ export function validateDomain(domain: string): {
       status: {
         domain,
         availability: 'unsupported',
-        source: 'validator',
+        resolver: 'validator',
         raw: { validator: null },
-        timestamp: Date.now(),
+        error: undefined,
       },
     };
   }

--- a/tests/test.js
+++ b/tests/test.js
@@ -51,8 +51,8 @@ const domains = [
 
   for (const d of allDomains) {
     const res = resultsMap[d.name];
-    const msg = `domain:${d.name}, expected:${d.availability}, got:${res.availability}, source:${res.source}`;
-    const hasNs = res.raw && res.raw[res.source] !== undefined;
+    const msg = `domain:${d.name}, expected:${d.availability}, got:${res.availability}, resolver:${res.resolver}`;
+    const hasNs = res.raw && res.raw[res.resolver] !== undefined;
     if (res.availability === d.availability && hasNs) {
       console.log(`PASSED: ${msg}`);
       passed++;


### PR DESCRIPTION
## Summary
- introduce `AdapterResponse` and refactor adapters to return it instead of throwing
- update `DomainStatus` fields (uses `resolver` and adapter raw map)
- rewrite core `check` flow to use new response shapes
- adjust validator and tests for new interface

## Testing
- `npm test` *(fails: 110/772 passed due to missing network access and whois command)*

------
https://chatgpt.com/codex/tasks/task_b_688d0cb3c4188326b86cebcde54f955e