### PR TITLE
feat: add verbose option to control logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Both `check` and `checkBatch` accept an optional `options` object:
 ```ts
 interface CheckOptions {
   logger?: Logger;
+  verbose?: boolean;
   concurrency?: number; // only used by checkBatch
   /** Only run adapters whose namespace starts with one of these prefixes */
   only?: string[];
@@ -65,6 +66,8 @@ interface CheckOptions {
 check(domain: string, options?: CheckOptions);
 checkBatch(domains: string[], options?: CheckOptions);
 ```
+
+Logging is disabled by default; pass `verbose: true` to enable log output.
 
 ### 5.3 Error Handling & Retries
 

--- a/src/adapters/hostAdapter.ts
+++ b/src/adapters/hostAdapter.ts
@@ -27,7 +27,6 @@ export class HostAdapter implements CheckerAdapter {
           raw: false,
         };
       }
-      console.error("dns.host error: ", err.code)
       // TODO: This is only the case for some TLDs, limit to TLDs.
       // E.g. for .lc, timeout => available.
       // if(err.code === 'ESERVFAIL' || err.code === 'ETIMEOUT') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,12 @@ const whoisApi = new WhoisApiAdapter(
   typeof process !== 'undefined' ? (process.env.WHOISXML_API_KEY as string | undefined) : undefined
 );
 
+const noopLogger: Pick<Console, 'info' | 'warn' | 'error'> = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
 function adapterAllowed(ns: string, opts: CheckOptions): boolean {
   if (opts.only && !opts.only.some((p) => ns.startsWith(p))) {
     return false;
@@ -31,7 +37,9 @@ function adapterAllowed(ns: string, opts: CheckOptions): boolean {
 }
 
 export async function check(domain: string, opts: CheckOptions = {}): Promise<DomainStatus> {
-  const logger = opts.logger ?? console;
+  const logger: Pick<Console, 'info' | 'warn' | 'error'> = opts.verbose
+    ? opts.logger ?? console
+    : noopLogger;
   logger.info('domain.check.start', { domain });
   const raw: Record<string, any> = {};
   const validated = validateDomain(domain);

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,7 @@ export interface TldConfigEntry {
 
 export interface CheckOptions {
   logger?: Console;
+  verbose?: boolean;
   concurrency?: number;
   /** Only run adapters whose namespace starts with one of these prefixes */
   only?: string[];


### PR DESCRIPTION
## Summary
- add `verbose` flag to CheckOptions and document default silent logging
- default to a noop logger unless verbose is true
- remove stray console error in host adapter
- revert verbose logger tests back to original domain tests

## Testing
- `npm test` *(fails: many domain checks returned unknown; config option tests 1/2)*

------
https://chatgpt.com/codex/tasks/task_b_688dc7f528b88326b1e2658d91617938