### PR TITLE
feat: add platform option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ interface CheckOptions {
   /** Skip adapters whose namespace starts with one of these prefixes */
   skip?: string[];
   tldConfig?: TldConfigEntry;
+  /** Select platform. Defaults to 'auto' */
+  platform?: 'auto' | 'node' | 'browser';
 }
 
 check(domain: string, options?: CheckOptions);
@@ -68,6 +70,8 @@ checkBatch(domains: string[], options?: CheckOptions);
 ```
 
 Logging is disabled by default; pass `verbose: true` to enable log output.
+The `platform` option lets you override automatic environment detection and force
+Node or browser-specific adapters.
 
 ### 5.3 Error Handling & Retries
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,10 @@
-import { DomainStatus, TldConfigEntry, AdapterResponse, CheckOptions } from './types.js';
+import {
+  DomainStatus,
+  TldConfigEntry,
+  AdapterResponse,
+  CheckOptions,
+  Platform,
+} from './types.js';
 import { HostAdapter } from './adapters/hostAdapter.js';
 import { DohAdapter } from './adapters/dohAdapter.js';
 import { RdapAdapter } from './adapters/rdapAdapter.js';
@@ -6,10 +12,13 @@ import { WhoisCliAdapter } from './adapters/whoisCliAdapter.js';
 import { WhoisApiAdapter } from './adapters/whoisApiAdapter.js';
 import { validateDomain } from './validator.js';
 
-const isNode =
-  typeof process !== 'undefined' &&
-  process.versions != null &&
-  process.versions.node != null;
+function detectNode(): boolean {
+  return (
+    typeof process !== 'undefined' &&
+    process.versions != null &&
+    process.versions.node != null
+  );
+}
 
 const host = new HostAdapter();
 const doh = new DohAdapter();
@@ -42,6 +51,8 @@ export async function check(domain: string, opts: CheckOptions = {}): Promise<Do
     : noopLogger;
   logger.info('domain.check.start', { domain });
   const raw: Record<string, any> = {};
+  const platform = opts.platform ?? Platform.AUTO;
+  const isNode = platform === Platform.AUTO ? detectNode() : platform === Platform.NODE;
   const validated = validateDomain(domain);
   if (validated.error) {
     logger.error("validation error: ", validated.error.message)

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,12 @@ export type AdapterSource =
   | 'whois.api'
   | 'app';
 
+export enum Platform {
+  AUTO = 'auto',
+  NODE = 'node',
+  BROWSER = 'browser',
+}
+
 export interface AdapterResponse {
   domain: string;
   availability: Availability;
@@ -69,4 +75,8 @@ export interface CheckOptions {
   /** Skip adapters whose namespace starts with one of these prefixes */
   skip?: string[];
   tldConfig?: TldConfigEntry;
+  /**
+   * Platform to run adapters on. Defaults to auto-detect based on environment.
+   */
+  platform?: Platform;
 }

--- a/tests/test.js
+++ b/tests/test.js
@@ -84,6 +84,14 @@ async function runConfigTests() {
   if (resSkip.resolver !== 'rdap') passed++;
   total++;
 
+  const resNode = await check('example.com', { platform: 'node', only: ['dns'] });
+  if (resNode.resolver === 'dns.host') passed++;
+  total++;
+
+  const resBrowser = await check('example.com', { platform: 'browser', only: ['dns'] });
+  if (resBrowser.resolver === 'dns.doh') passed++;
+  total++;
+
   console.log(`Config option tests passed: ${passed}/${total}`);
   if (passed !== total) {
     process.exitCode = 1;


### PR DESCRIPTION
## Summary
- add Platform enum and platform override to options
- allow selecting node or browser adapters
- document platform option and extend tests

## Testing
- `npm test` *(fails: Total tests passed: 51/749, Config option tests passed: 2/4)*

------
https://chatgpt.com/codex/tasks/task_b_688e643e161c8326bc0cff73cf08103a